### PR TITLE
Remove --ssh-key-expire-after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
       - name: deploy
         uses: actions/gcloud/cli@6a43f01e0e930f639b90eec0670e88ba3ec4aba3
         with:
-          args: compute ssh ${{ secrets.GCLOUD_INSTANCE }} --command 'cd /home/exaego/exaego && git pull && export NVM_DIR='/home/exaego/.nvm' && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && pm2 restart exaego' --force-key-file-overwrite --strict-host-key-checking=no --zone ${{ secrets.GCLOUD_ZONE }} --ssh-key-expire-after=5m
+          args: compute ssh ${{ secrets.GCLOUD_INSTANCE }} --command 'cd /home/exaego/exaego && git pull && export NVM_DIR='/home/exaego/.nvm' && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && pm2 restart exaego' --force-key-file-overwrite --strict-host-key-checking=no --zone ${{ secrets.GCLOUD_ZONE }}


### PR DESCRIPTION
A better solution might be creating an updated local fork, but currently the official gcloud Action repository is somewhat behind.

This is the simplest workaround I guess.