### PR TITLE
Fix command regex

### DIFF
--- a/ego/middlewares/commands/alias.js
+++ b/ego/middlewares/commands/alias.js
@@ -7,7 +7,7 @@ const RESERVED_WORDS = [
 
 function alias(message, connector, localContext, connectorContext, globalContext) {
   const localMessage = localContext.message || {};
-  const pattern = /^\s*(alias)(?:\s+(.+))*/i;
+  const pattern = /(alias)(?:\s+(.+))*/i;
   if (!localMessage.content) {
     return true;
   }

--- a/ego/middlewares/commands/pso2.js
+++ b/ego/middlewares/commands/pso2.js
@@ -3,7 +3,7 @@ const { parseDateString } = require('../../../utils/date');
 
 function pso2(message, connector, localContext, connectorContext, globalContext) {
   const localMessage = localContext.message || {};
-  const pattern = /^\s*(pso2)(?:\s+(.+))*/i;
+  const pattern = /(pso2)(?:\s+(.+))*/i;
   if (!localMessage.content) {
     return true;
   }

--- a/ego/middlewares/commands/trigger.js
+++ b/ego/middlewares/commands/trigger.js
@@ -1,6 +1,6 @@
 function trigger(message, connector, localContext, connectorContext, globalContext) {
   const localMessage = localContext.message || {};
-  const pattern = /^\s*(trigger)(?:\s+(.+))*/i;
+  const pattern = /(trigger)(?:\s+(.+))*/i;
   if (!localMessage.content) {
     return true;
   }

--- a/ego/middlewares/commands/youtube.js
+++ b/ego/middlewares/commands/youtube.js
@@ -2,7 +2,7 @@ const ytdl = require('ytdl-core');
 
 function youtube(message, connector, localContext, connectorContext, globalContext) {
   const localMessage = localContext.message || {};
-  const pattern = /^\s*(youtube)(?:\s+(.+))*/i;
+  const pattern = /(youtube)(?:\s+(.+))*/i;
   if (!localMessage.content) {
     return true;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exaego",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "simple discord bot",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Commands never match because trigger phrases in input strings aren't stripped off.
Implementing a temporary fix with less strict regex patterns.